### PR TITLE
Add support for newline characters, and repeating table rows

### DIFF
--- a/OpenXMLTemplates/ControlReplacers/ControlReplacer.cs
+++ b/OpenXMLTemplates/ControlReplacers/ControlReplacer.cs
@@ -133,22 +133,39 @@ namespace OpenXMLTemplates.ControlReplacers
         }
         
         
+	    /// <summary>
+		/// Sets the text of the OpenXmlElement and removes the default placeholder style that is associated by default with content controls
+		/// </summary>
+		protected static void SetTextAndRemovePlaceholderFormat(OpenXmlElement element, string newValue) {
+			if (newValue == null)
+				return;
 
-        /// <summary>
-        /// Sets the text of the OpenXmlElement and removes the default placeholder style that is associated by default with content controls
-        /// </summary>
-        protected static void SetTextAndRemovePlaceholderFormat(OpenXmlElement element, string newValue)
-        {
-            if (newValue == null)
-                return;
+			string[] newlineArray = { Environment.NewLine, "\n", "\r\n", "\n\r" };
+			string[] textArray = newValue.Split(newlineArray, StringSplitOptions.None);
+			bool first = true;
 
-            Text textElement = element.SetText(newValue);
+			var textElement = element.GetTextElement();
+			var textElementParent = textElement.Parent;
 
-            //Check if the style is the default placeholder style and remove it if it is
-            if (textElement?.Parent is Run run && run.RunProperties?.RunStyle?.Val == "PlaceholderText")
-                run.RunProperties.RunStyle.Val = "";
-        }
+			foreach (var line in textArray) {
 
+				if (!first) {
+					textElementParent.Append(new Break());
+				}
+
+				textElement.Parent.Append(new Text(line));
+
+				first = false;
+			}
+
+			//Check if the style is the default placeholder style and remove it if it is
+			if (textElement?.Parent is Run run && run.RunProperties?.RunStyle?.Val == "PlaceholderText") {
+				run.RunProperties.RunStyle.Val = "";
+			}
+
+			textElement.Remove();
+
+		}
 
     }
 }

--- a/OpenXMLTemplates/ControlReplacers/RepeatingControlReplacer.cs
+++ b/OpenXMLTemplates/ControlReplacers/RepeatingControlReplacer.cs
@@ -134,9 +134,10 @@ namespace OpenXMLTemplates.ControlReplacers
             return null;
         }
 
-        private static OpenXmlElement GetSdtContent(SdtElement original)
+         private static OpenXmlElement GetSdtContent(SdtElement original)
         {
-            return original.GetFirstChild<SdtContentBlock>() ??
+            return original.GetFirstChild<SdtContentRow>() ?? 
+                   original.GetFirstChild<SdtContentBlock>() ??
                    (OpenXmlElement) original.GetFirstChild<SdtContentRun>();
         }
 


### PR DESCRIPTION
We found two blocking issues when using the library. 

First was that text inserted with \n or \r\n characters, wasn't being properly formatted.  

Second was that the code would throw a null reference exception when using a repeating content control wrapped around a table row.  

This PR fixes both of those issues.  One other thing to note is that with VS 2019, no one on the team was able to open the solution or project files. We kept getting unsupported project type errors.  Recreating a new project and pulling in the files worked just fine. Code edits were made in that project. Code was then copy pasted into Github for this PR.  Might be nice to take a look at the project with VS2019 and see what's up. Hence no unit tests for this because of the extra work required to get that project running.

Thanks for this project!