### PR TITLE
Return OpenXmlPackage for SaveAs

### DIFF
--- a/OpenXMLTemplates/Documents/TemplateDocument.cs
+++ b/OpenXMLTemplates/Documents/TemplateDocument.cs
@@ -97,9 +97,9 @@ namespace OpenXMLTemplates.Documents
             WordprocessingDocument.Close();
         }
 
-        public void SaveAs(string path)
+        public OpenXmlPackage SaveAs(string path)
         {
-            WordprocessingDocument.SaveAs(path);
+            return WordprocessingDocument.SaveAs(path);
         }
 
         public void RemoveControl(ContentControl contentControl)


### PR DESCRIPTION
The file being saved cannot be accessed event after call templateDocument.Close()
You need call templateDocment.SaveAs("other-file").Close() before access the `other-file`