### PR TITLE
Tweaks to let templating continue when variable source has a null object

### DIFF
--- a/OpenXMLTemplates/ControlReplacers/Utils/ConditionalUtils.cs
+++ b/OpenXMLTemplates/ControlReplacers/Utils/ConditionalUtils.cs
@@ -50,16 +50,9 @@ namespace OpenXMLTemplates.ControlReplacers
                         if (lastOperator != null)
                         {
                             object nextValue;
-                            try
-                            {
-                                nextValue = variableSource.GetVariable(otherParameter);
-                            }
-                            catch (VariableNotFoundException)
-                            {
-                                nextValue = otherParameter;
-                            }
+                                nextValue = variableSource.GetVariable(otherParameter) ?? otherParameter;
 
-                            var nextValueEvaluated = EvaluateVariableValue(nextValue);
+                                var nextValueEvaluated = EvaluateVariableValue(nextValue);
 
                             switch (lastOperator)
                             {

--- a/OpenXMLTemplates/Variables/VariableSource.cs
+++ b/OpenXMLTemplates/Variables/VariableSource.cs
@@ -137,8 +137,8 @@ namespace OpenXMLTemplates.Variables
             }
             else
             {
-                if (lastNestedStructure == null) throw new IncorrectIdentifierException(fullIdentifier);
-                if (!lastNestedStructure.Contains(singleIdentifier))
+               
+                if (lastNestedStructure == null || !lastNestedStructure.Contains(singleIdentifier))
                 {
                     if (ThrowIfNotFound) throw new VariableNotFoundException(fullIdentifier);
 

--- a/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
+++ b/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
@@ -26,8 +26,8 @@ namespace OpenXMLTempaltesTest
 
             Assert.AreEqual("12345", source.GetVariable<string>("phones.[1]"));
 
+            Assert.Throws<VariableNotFoundException>((() => source.GetVariable<string>("name.street")));
             Assert.Throws<VariableNotFoundException>((() => source.GetVariable<string>("address.streeets")));
-            Assert.Throws<IncorrectIdentifierException>((() => source.GetVariable<string>("name.street")));
             Assert.Throws<IncorrectVariableTypeException>((() => source.GetVariable<int>("name")));
         }
     }


### PR DESCRIPTION
We have many complex templates. One thing that we were struggling with was that our json objects sometimes have null properties.

The schema might look like this...
```
{  
    "employee": {  
        "name":       "sonoo",   
        "salary":      56000,   
        "married":    true  
    }  
} 
``` 
Or, like this...
```
{  
    "employee": null
}  
```

Our template would always contain the variable value. However, as the code is currently you'd always end up with an exception. "The variable "x" can't be processed. Most likely a nested structure that is referenced is not a dictionary or the variable identifier was entered incorrectly"

This was undesirable because templates needed to stay fixed, contain the templated path, but not error out.  ThrowIfNotFound was unhelpful because everything was being caught be the first if statement.  

With this modification ThrowIfNotFound now works as expected.


