### PR TITLE
Fixes control replacer newline definitions

### DIFF
--- a/OpenXMLTemplates/ControlReplacers/ControlReplacer.cs
+++ b/OpenXMLTemplates/ControlReplacers/ControlReplacer.cs
@@ -191,7 +191,7 @@ namespace OpenXMLTemplates.ControlReplacers
             if (newValue == null)
                 return;
 
-            string[] newlineArray = {Environment.NewLine, "\\r\\n", "\\n\\r", "\\n"};
+            string[] newlineArray = {Environment.NewLine, "\r\n", "\n\r", "\n"};
             var textArray = newValue.Split(newlineArray, StringSplitOptions.None);
 
             var texts = element.Descendants<Text>().ToList();

--- a/OpenXMLTemplatesTest/ControlReplacersTests/VariableControlReplacerTests/data.json
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/VariableControlReplacerTests/data.json
@@ -8,5 +8,5 @@
       "province": "Plovdiv"
     }
   },
-  "paragraph": "This is a paragraph. \\n This should be a new line \\n\\r This is another new line"
+  "paragraph": "This is a paragraph. \n This should be a new line \n\r This is another new line"
 }


### PR DESCRIPTION
Fixes issue with newlines in templates ("\n") not being properly identified. 

The escaping of newline characters in ControlReplacer ("\\\n", etc.) isn't needed because all newline characters ("\n") are already valid escape sequences.