### PR TITLE
Update DocumentFormatXml to V3.0.1

### DIFF
--- a/OpenXMLTemplates/Documents/TemplateDocument.cs
+++ b/OpenXMLTemplates/Documents/TemplateDocument.cs
@@ -88,12 +88,14 @@ namespace OpenXMLTemplates.Documents
             if (save)
                 WordprocessingDocument.Save();
 
-            WordprocessingDocument.Close();
+            //WordprocessingDocument.Close();
         }
 
         public OpenXmlPackage SaveAs(string path)
         {
-            return WordprocessingDocument.SaveAs(path);
+            var clonedDoc = WordprocessingDocument.Clone(path);
+            clonedDoc.Save();
+            return clonedDoc;
         }
 
         public void RemoveControl(ContentControl contentControl)

--- a/OpenXMLTemplates/OpenXMLTemplates.csproj
+++ b/OpenXMLTemplates/OpenXMLTemplates.csproj
@@ -22,7 +22,7 @@
         <OldToolsVersion>2.0</OldToolsVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+        <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 </Project>

--- a/OpenXMLTemplates/OpenXMLTemplates.csproj
+++ b/OpenXMLTemplates/OpenXMLTemplates.csproj
@@ -20,6 +20,8 @@
         <UpgradeBackupLocation>
         </UpgradeBackupLocation>
         <OldToolsVersion>2.0</OldToolsVersion>
+        <PackageVersion>2.0.6</PackageVersion>
+        <Version>2.0.6</Version>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />

--- a/OpenXMLTemplates/OpenXMLTemplates.csproj
+++ b/OpenXMLTemplates/OpenXMLTemplates.csproj
@@ -20,8 +20,6 @@
         <UpgradeBackupLocation>
         </UpgradeBackupLocation>
         <OldToolsVersion>2.0</OldToolsVersion>
-        <PackageVersion>2.0.6</PackageVersion>
-        <Version>2.0.6</Version>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />

--- a/OpenXMLTemplatesTest/ControlReplacersTests/ConditionalControlReplacerTest/ConditionalsTests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/ConditionalControlReplacerTest/ConditionalsTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
@@ -26,15 +27,15 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 
 
-            Assert.IsNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1"));
-            Assert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled2"));
-            Assert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled3"));
-            Assert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1_or_enabled2"));
-            Assert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled3_or_enabled2"));
-            Assert.IsNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1_and_enabled2"));
-            Assert.NotNull(
+            ClassicAssert.IsNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1"));
+            ClassicAssert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled2"));
+            ClassicAssert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled3"));
+            ClassicAssert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1_or_enabled2"));
+            ClassicAssert.NotNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled3_or_enabled2"));
+            ClassicAssert.IsNull(doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1_and_enabled2"));
+            ClassicAssert.NotNull(
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled1_not_and_enabled2"));
-            Assert.IsNull(
+            ClassicAssert.IsNull(
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled2_and_enabled3_not"));
             doc.WordprocessingDocument.AssertValid();
 

--- a/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/ConditionalDropdownControlReplacerTest/ConditionalsTests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/ConditionalDropdownControlReplacerTest/ConditionalsTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.ControlReplacers.DropdownControlReplacers;
 using OpenXMLTemplates.Documents;
@@ -29,13 +30,13 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.DropdownControlReplacersTes
             var c3 = doc.WordprocessingDocument.FindContentControl("conditional_isInvalid_or_isValid");
 
 
-            Assert.NotNull(c1);
-            Assert.NotNull(c2);
-            Assert.NotNull(c3);
+            ClassicAssert.NotNull(c1);
+            ClassicAssert.NotNull(c2);
+            ClassicAssert.NotNull(c3);
 
-            Assert.AreEqual("THIS IS VALID", c1.GetTextElement().Text);
-            Assert.AreEqual("THIS IS VALID", c2.GetTextElement().Text);
-            Assert.AreEqual("THIS IS VALID", c3.GetTextElement().Text);
+            ClassicAssert.AreEqual("THIS IS VALID", c1.GetTextElement().Text);
+            ClassicAssert.AreEqual("THIS IS VALID", c2.GetTextElement().Text);
+            ClassicAssert.AreEqual("THIS IS VALID", c3.GetTextElement().Text);
             doc.WordprocessingDocument.AssertValid();
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 

--- a/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/SingularsTest/SingularsTests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/SingularsTest/SingularsTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.ControlReplacers.DropdownControlReplacers;
 using OpenXMLTemplates.Documents;
@@ -27,11 +28,11 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.DropdownControlReplacersTes
             var c1 = doc.WordprocessingDocument.FindContentControl(singularReplacer.TagName + "_sellers");
             var c2 = doc.WordprocessingDocument.FindContentControl(singularReplacer.TagName + "_buyers");
 
-            Assert.NotNull(c1);
-            Assert.NotNull(c2);
+            ClassicAssert.NotNull(c1);
+            ClassicAssert.NotNull(c2);
 
-            Assert.AreEqual("sellers are", c1.GetTextElement().Text);
-            Assert.AreEqual("buyer", c2.GetTextElement().Text);
+            ClassicAssert.AreEqual("sellers are", c1.GetTextElement().Text);
+            ClassicAssert.AreEqual("buyer", c2.GetTextElement().Text);
             doc.WordprocessingDocument.AssertValid();
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 

--- a/OpenXMLTemplatesTest/ControlReplacersTests/PictureControlReplacerTests/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/PictureControlReplacerTests/Tests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
@@ -31,13 +32,13 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.PictureControlReplacerTests
             replacer.ReplaceAll(doc, src);
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 
-            Assert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtBlock",
+            ClassicAssert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtBlock",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "picture1").GetType()
                     .ToString());
-            Assert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtBlock",
+            ClassicAssert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtBlock",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "picture2").GetType()
                     .ToString());
-            Assert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtBlock",
+            ClassicAssert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtBlock",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "picture3").GetType()
                     .ToString());
 

--- a/OpenXMLTemplatesTest/ControlReplacersTests/RepeatingControlTests/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/RepeatingControlTests/Tests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
@@ -27,11 +28,11 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.RepeatingControlTests
             replacer.ReplaceAll(doc, src);
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 
-            Assert.AreEqual(4,
+            ClassicAssert.AreEqual(4,
                 doc.WordprocessingDocument.ContentControls().Count(cc =>
                     cc.GetContentControlTag() != null && cc.GetContentControlTag().StartsWith("repeatingitem")));
 
-            Assert.AreEqual(5,
+            ClassicAssert.AreEqual(5,
                 doc.WordprocessingDocument.ContentControls().Count(cc =>
                     cc.GetContentControlTag() != null && cc.GetContentControlTag() == "repeating_nestedList"));
 

--- a/OpenXMLTemplatesTest/ControlReplacersTests/VariableControlReplacerTests/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/VariableControlReplacerTests/Tests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Wordprocessing;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
@@ -29,31 +30,31 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.VariableControlReplacerTest
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 
             foreach (var namecc in doc.WordprocessingDocument.FindContentControls(replacer.TagName + "_" + "name"))
-                Assert.AreEqual("Antonio Conte", namecc.GetTextElement().Text);
+                ClassicAssert.AreEqual("Antonio Conte", namecc.GetTextElement().Text);
 
-            Assert.AreEqual("Elm street",
+            ClassicAssert.AreEqual("Elm street",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "address.street")
                     .GetTextElement().Text);
-            Assert.AreEqual("23",
+            ClassicAssert.AreEqual("23",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "address.number")
                     .GetTextElement().Text);
-            Assert.AreEqual("Novakovo",
+            ClassicAssert.AreEqual("Novakovo",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "address.city.name")
                     .GetTextElement().Text);
-            Assert.AreEqual("Plovdiv",
+            ClassicAssert.AreEqual("Plovdiv",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "address.city.province")
                     .GetTextElement().Text);
 
             var cc = doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "paragraph");
-            Assert.AreEqual(0, cc.Descendants<Break>().Count());
+            ClassicAssert.AreEqual(0, cc.Descendants<Break>().Count());
 
             //Nested
-            Assert.AreEqual("Elm street",
+            ClassicAssert.AreEqual("Elm street",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "street").GetTextElement().Text);
-            Assert.AreEqual("Novakovo",
+            ClassicAssert.AreEqual("Novakovo",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "name_city").GetTextElement()
                     .Text);
-            Assert.AreEqual("Plovdiv",
+            ClassicAssert.AreEqual("Plovdiv",
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_" + "province").GetTextElement()
                     .Text);
 

--- a/OpenXMLTemplatesTest/CustomPartAdditionTest/CustomPartAdditionTests.cs
+++ b/OpenXMLTemplatesTest/CustomPartAdditionTest/CustomPartAdditionTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.Utils;
 
@@ -18,10 +19,10 @@ namespace OpenXMLTempaltesTest.CustomPartAdditionTest
 
             doc.AddOrReplaceCustomXmlPart(xData);
 
-            Assert.IsNotNull(doc.GetCustomXmlPart("XmlCustomPart"));
+            ClassicAssert.IsNotNull(doc.GetCustomXmlPart("XmlCustomPart"));
             doc.AssertValid();
 
-            doc.Close();
+            //doc.Close();
         }
 
         [Test]
@@ -37,12 +38,12 @@ namespace OpenXMLTempaltesTest.CustomPartAdditionTest
             doc.AddOrReplaceCustomXmlPart(xData2);
 
             var foundPart = doc.GetCustomXmlPart("XmlCustomPart");
-            Assert.IsNotNull(foundPart);
-            Assert.DoesNotThrow(() => doc.GetCustomXmlParts().Single(e => e.GetNamespace() == "XmlCustomPart"));
+            ClassicAssert.IsNotNull(foundPart);
+            ClassicAssert.DoesNotThrow(() => doc.GetCustomXmlParts().Single(e => e.GetNamespace() == "XmlCustomPart"));
 
             doc.AssertValid();
 
-            doc.Close();
+            //doc.Close();
         }
 
         private WordprocessingDocument GetDoc()

--- a/OpenXMLTemplatesTest/EngineTest/EngineTest.cs
+++ b/OpenXMLTemplatesTest/EngineTest/EngineTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Engine;
@@ -35,25 +36,25 @@ namespace OpenXMLTempaltesTest.EngineTest
             }
 
 
-            Assert.AreEqual("Antoniantaz", GetText("variable_name", 0));
-            Assert.AreEqual("1", GetText("variable_index", 0));
-            Assert.AreEqual("2", GetText("variable_index", 1));
-            Assert.AreEqual("1", GetText("variable_index", 2));
-            Assert.AreEqual("2", GetText("variable_index", 3));
+            ClassicAssert.AreEqual("Antoniantaz", GetText("variable_name", 0));
+            ClassicAssert.AreEqual("1", GetText("variable_index", 0));
+            ClassicAssert.AreEqual("2", GetText("variable_index", 1));
+            ClassicAssert.AreEqual("1", GetText("variable_index", 2));
+            ClassicAssert.AreEqual("2", GetText("variable_index", 3));
 
-            Assert.AreEqual(4, wd.FindContentControls("repeating_streets").Count());
-            Assert.AreEqual(2, wd.FindContentControls("variable_city").Count());
-            Assert.AreEqual(9, wd.FindContentControls("variable_name").Count());
+            ClassicAssert.AreEqual(4, wd.FindContentControls("repeating_streets").Count());
+            ClassicAssert.AreEqual(2, wd.FindContentControls("variable_city").Count());
+            ClassicAssert.AreEqual(9, wd.FindContentControls("variable_name").Count());
 
-            Assert.AreEqual("Antoniantaz", GetText("variable_name", 1));
-            Assert.AreEqual("Antoniantaz", GetText("variable_name", 2));
+            ClassicAssert.AreEqual("Antoniantaz", GetText("variable_name", 1));
+            ClassicAssert.AreEqual("Antoniantaz", GetText("variable_name", 2));
 
-            Assert.AreEqual("Novigrad", GetText("variable_name", 3));
-            Assert.AreEqual("First street", GetText("variable_name", 4));
-            Assert.AreEqual("Second Street", GetText("variable_name", 5));
-            Assert.AreEqual("Khan", GetText("variable_name", 6));
+            ClassicAssert.AreEqual("Novigrad", GetText("variable_name", 3));
+            ClassicAssert.AreEqual("First street", GetText("variable_name", 4));
+            ClassicAssert.AreEqual("Second Street", GetText("variable_name", 5));
+            ClassicAssert.AreEqual("Khan", GetText("variable_name", 6));
 
-            Assert.AreEqual("Novigrad", GetText("variable_city.name", 0));
+            ClassicAssert.AreEqual("Novigrad", GetText("variable_city.name", 0));
 
 
             doc.WordprocessingDocument.AssertValid();
@@ -83,7 +84,7 @@ namespace OpenXMLTempaltesTest.EngineTest
 
             doc.SaveAs(this.CurrentFolder() + "result.docx");
 
-            Assert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtRun",
+            ClassicAssert.AreEqual("DocumentFormat.OpenXml.Wordprocessing.SdtRun",
                 doc.WordprocessingDocument.FindContentControl(imageReplacerTag + "_" + "pic").GetType()
                     .ToString());
         }

--- a/OpenXMLTemplatesTest/OpenXMLTemplatesTest.csproj
+++ b/OpenXMLTemplatesTest/OpenXMLTemplatesTest.csproj
@@ -10,9 +10,9 @@
         <OldToolsVersion>2.0</OldToolsVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="nunit" Version="4.0.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\OpenXMLTemplates\OpenXMLTemplates.csproj" />

--- a/OpenXMLTemplatesTest/TestUtils.cs
+++ b/OpenXMLTemplatesTest/TestUtils.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace OpenXMLTempaltesTest
 {
@@ -39,7 +40,7 @@ namespace OpenXMLTempaltesTest
             }
 
             TestContext.Out.WriteLine("Found {0} OpenXml errors", count);
-            Assert.IsEmpty(errors);
+            ClassicAssert.IsEmpty(errors);
         }
     }
 }

--- a/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
+++ b/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OpenXMLTemplates.Variables;
 using OpenXMLTemplates.Variables.Exceptions;
 
@@ -21,14 +22,14 @@ namespace OpenXMLTempaltesTest
 
             var source = new VariableSource(data);
 
-            Assert.AreEqual("MyName", source.GetVariable<string>("name"));
-            Assert.AreEqual("MyStreet", source.GetVariable<string>("address.street"));
+            ClassicAssert.AreEqual("MyName", source.GetVariable<string>("name"));
+            ClassicAssert.AreEqual("MyStreet", source.GetVariable<string>("address.street"));
 
-            Assert.AreEqual("12345", source.GetVariable<string>("phones.[1]"));
+            ClassicAssert.AreEqual("12345", source.GetVariable<string>("phones.[1]"));
 
-            Assert.Throws<VariableNotFoundException>(() => source.GetVariable<string>("name.street"));
-            Assert.Throws<VariableNotFoundException>(() => source.GetVariable<string>("address.streeets"));
-            Assert.Throws<IncorrectVariableTypeException>(() => source.GetVariable<int>("name"));
+            ClassicAssert.Throws<VariableNotFoundException>(() => source.GetVariable<string>("name.street"));
+            ClassicAssert.Throws<VariableNotFoundException>(() => source.GetVariable<string>("address.streeets"));
+            ClassicAssert.Throws<IncorrectVariableTypeException>(() => source.GetVariable<int>("name"));
         }
 
         [Test]
@@ -41,7 +42,7 @@ namespace OpenXMLTempaltesTest
 
             var source = new VariableSource(data);
 
-            Assert.AreEqual("", source.GetVariable<string>("prices(N2)"));
+            ClassicAssert.AreEqual("", source.GetVariable<string>("prices(N2)"));
         }
 
         [Test]
@@ -54,7 +55,7 @@ namespace OpenXMLTempaltesTest
 
             var source = new VariableSource(data);
 
-            Assert.AreEqual("12,345.00", source.GetVariable<string>("prices.[1](N2)"));
+            ClassicAssert.AreEqual("12,345.00", source.GetVariable<string>("prices.[1](N2)"));
         }
     }
 }

--- a/OpenXMLTemplatesTest/XMLReplacementTest/XmlReplacementTests.cs
+++ b/OpenXMLTemplatesTest/XMLReplacementTest/XmlReplacementTests.cs
@@ -24,7 +24,7 @@ namespace OpenXMLTempaltesTest.XMLReplacementTest
             doc.AssertValid();
 
 //            doc.SaveAs(TestContext.CurrentContext.TestDirectory + "/XMLReplacementTest/result.docx");
-            doc.Close();
+            //doc.Close();
         }
 
         [Test]
@@ -37,11 +37,11 @@ namespace OpenXMLTempaltesTest.XMLReplacementTest
 
             doc.AddOrReplaceCustomXmlPart(xData);
 
-            doc.Close();
+            //doc.Close();
 
 //            Can't be tested directly, because word needs to reevaluate the content controls first         
-//            Assert.AreEqual("NewItem1Value", doc.FindContentControl("item1").GetTextElement().Text);
-//            Assert.AreEqual("NewItem2Value", doc.FindContentControl("item2").GetTextElement().Text);
+//            ClassicAssert.AreEqual("NewItem1Value", doc.FindContentControl("item1").GetTextElement().Text);
+//            ClassicAssert.AreEqual("NewItem2Value", doc.FindContentControl("item2").GetTextElement().Text);
         }
     }
 }


### PR DESCRIPTION
Current OpenXmlPackage V2.20.0 does not support SaveAs anymore. Details here: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.packaging.openxmlpackage.close?view=openxml-2.20.0 

SaveAs in Version 2.0.5 lead to an error. So I had to update to newest version.

I also updated NUnit and changed Assert to ClassicAssert as quick solution.