### PR TITLE
Ensure Consistent Numeric Formatting in Unit Tests Across Different Locales

### DIFF
--- a/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
+++ b/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using NUnit.Framework;
 using OpenXMLTemplates.Variables;
 using OpenXMLTemplates.Variables.Exceptions;
@@ -47,6 +48,9 @@ namespace OpenXMLTempaltesTest
         [Test]
         public void Format_Numeric_Fields()
         {
+            // Set the current culture to invariant culture for consistent numeric formatting across different environments. 
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
             var data = new Dictionary<string, object>
             {
                 { "prices", new List<string> { "123", "12345.0001" } }


### PR DESCRIPTION
**Overview**
This pull request introduces a modification to the Format_Numeric_Fields unit test to set the CultureInfo.CurrentCulture to CultureInfo.InvariantCulture. This change ensures that the numeric formatting remains consistent, regardless of the regional settings of the system on which the tests are executed.

**Background**
Unit tests often fail across different environments due to variations in culture settings, especially when it comes to numeric, date, and time formats. Such inconsistencies can lead to failed tests on some systems while passing on others, which is highly undesirable for maintaining stable and reliable build processes.

**Request for Review**
I request a review from the team to ensure that this approach aligns with our overall testing strategy and to confirm the robustness of the test modifications.