### PR TITLE
Fix for Incorrect Variable Source Assignment in Nested Controls

### DIFF
--- a/OpenXMLTemplates/ControlReplacers/RepeatingControlReplacer.cs
+++ b/OpenXMLTemplates/ControlReplacers/RepeatingControlReplacer.cs
@@ -80,8 +80,8 @@ namespace OpenXMLTemplates.ControlReplacers
                             //Support old styled documents
                             var innerRep1 = new InnerRepeatingVariableControlReplacer();
                             var innerRep2 = new InnerRepeatingConditionalRemoveControlReplacer();
-                            innerRep1.ReplaceAll(ex.Controls, ex.VariableSource);
-                            innerRep2.ReplaceAll(ex.Controls, ex.VariableSource);
+                            innerRep1.ReplaceAll(ex.Controls, innerSource);
+                            innerRep2.ReplaceAll(ex.Controls, innerSource);
 
                             break;
                         }


### PR DESCRIPTION
This pull request resolves an issue identified in RepeatingControlTests within Tests.cs, where the document fields were not being populated with data from data.json. Specifically, the complexItems array was causing the problem, leading to the addition of empty lines instead of the expected data in the output document.

**Original Issue Description.**
The original problem occurred when nested controls were mistakenly assigned the entire VariableSource instead of the specific nested inner source required for the complexItems array. This resulted in the document rendering two empty rows under "Complex, Legacy (using repeatingitem)" despite the presence of data meant to populate these fields.

**Changes Made.**
Corrected the source assignment in the code to ensure that nested controls receive the correct nested inner source from VariableSource.

**Request for Review.**
I kindly request a review of this pull request to confirm the fix resolves the issue without affecting other functionalities. Any feedback or additional checks suggested by the team would be greatly appreciated to ensure comprehensive resolution.

**Connection to Original Issue.**
This pull request aims to address and close the issue concerning data population in nested controls. The issue discussion can be found here: #50 