### PR TITLE
chore: update dependencies and fix minor issues

### DIFF
--- a/OpenXMLTemplates/Documents/TemplateDocument.cs
+++ b/OpenXMLTemplates/Documents/TemplateDocument.cs
@@ -83,18 +83,12 @@ namespace OpenXMLTemplates.Documents
             WordprocessingDocument?.Dispose();
         }
 
-
-        public void Close(bool save = false)
-        {
-            if (save)
-                WordprocessingDocument.Save();
-
-            WordprocessingDocument.Close();
-        }
-
         public OpenXmlPackage SaveAs(string path)
         {
-            return WordprocessingDocument.SaveAs(path);
+            // return WordprocessingDocument.SaveAs(path);
+            var clone = WordprocessingDocument.Clone(path);
+            clone.Save();
+            return clone;
         }
 
         public void RemoveControl(ContentControl contentControl)

--- a/OpenXMLTemplates/OpenXMLTemplates.csproj
+++ b/OpenXMLTemplates/OpenXMLTemplates.csproj
@@ -22,7 +22,7 @@
         <OldToolsVersion>2.0</OldToolsVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+        <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 </Project>

--- a/OpenXMLTemplatesTest/ControlRemovalTest/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlRemovalTest/Tests.cs
@@ -6,7 +6,7 @@ using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Engine;
 using OpenXMLTemplates.Variables;
-namespace OpenXMLTempaltesTest.ControlRemovalTest
+namespace OpenXMLTemplatesTest.ControlRemovalTest
 {
     public class Tests
     {

--- a/OpenXMLTemplatesTest/ControlReplacersTests/ConditionalControlReplacerTest/ConditionalsTests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/ConditionalControlReplacerTest/ConditionalsTests.cs
@@ -5,7 +5,7 @@ using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.ControlReplacersTests.
+namespace OpenXMLTemplatesTest.ControlReplacersTests.
     ConditionalControlReplacerTest
 {
     public class Tests
@@ -37,8 +37,6 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.
             Assert.IsNull(
                 doc.WordprocessingDocument.FindContentControl(replacer.TagName + "_enabled2_and_enabled3_not"));
             doc.WordprocessingDocument.AssertValid();
-
-            doc.Close();
         }
     }
 }

--- a/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/ConditionalDropdownControlReplacerTest/ConditionalsTests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/ConditionalDropdownControlReplacerTest/ConditionalsTests.cs
@@ -5,7 +5,7 @@ using OpenXMLTemplates.ControlReplacers.DropdownControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.ControlReplacersTests.DropdownControlReplacersTests.
+namespace OpenXMLTemplatesTest.ControlReplacersTests.DropdownControlReplacersTests.
     ConditionalDropdownControlReplacerTest
 {
     public class Tests
@@ -38,8 +38,6 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.DropdownControlReplacersTes
             Assert.AreEqual("THIS IS VALID", c3.GetTextElement().Text);
             doc.WordprocessingDocument.AssertValid();
             doc.SaveAs(this.CurrentFolder() + "result.docx");
-
-            doc.Close();
         }
     }
 }

--- a/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/SingularsTest/SingularsTests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/DropdownControlReplacersTests/SingularsTest/SingularsTests.cs
@@ -5,7 +5,7 @@ using OpenXMLTemplates.ControlReplacers.DropdownControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.ControlReplacersTests.DropdownControlReplacersTests.SingularsTest
+namespace OpenXMLTemplatesTest.ControlReplacersTests.DropdownControlReplacersTests.SingularsTest
 {
     public class Tests
     {
@@ -34,8 +34,6 @@ namespace OpenXMLTempaltesTest.ControlReplacersTests.DropdownControlReplacersTes
             Assert.AreEqual("buyer", c2.GetTextElement().Text);
             doc.WordprocessingDocument.AssertValid();
             doc.SaveAs(this.CurrentFolder() + "result.docx");
-
-            doc.Close();
         }
     }
 }

--- a/OpenXMLTemplatesTest/ControlReplacersTests/PictureControlReplacerTests/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/PictureControlReplacerTests/Tests.cs
@@ -5,7 +5,7 @@ using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.ControlReplacersTests.PictureControlReplacerTests
+namespace OpenXMLTemplatesTest.ControlReplacersTests.PictureControlReplacerTests
 {
     public class Tests
     {

--- a/OpenXMLTemplatesTest/ControlReplacersTests/RepeatingControlTests/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/RepeatingControlTests/Tests.cs
@@ -6,7 +6,7 @@ using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.ControlReplacersTests.RepeatingControlTests
+namespace OpenXMLTemplatesTest.ControlReplacersTests.RepeatingControlTests
 {
     public class Tests
     {

--- a/OpenXMLTemplatesTest/ControlReplacersTests/VariableControlReplacerTests/Tests.cs
+++ b/OpenXMLTemplatesTest/ControlReplacersTests/VariableControlReplacerTests/Tests.cs
@@ -7,7 +7,7 @@ using OpenXMLTemplates.ControlReplacers;
 using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.ControlReplacersTests.VariableControlReplacerTests
+namespace OpenXMLTemplatesTest.ControlReplacersTests.VariableControlReplacerTests
 {
     public class Tests
     {

--- a/OpenXMLTemplatesTest/CustomPartAdditionTest/CustomPartAdditionTests.cs
+++ b/OpenXMLTemplatesTest/CustomPartAdditionTest/CustomPartAdditionTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using OpenXMLTemplates;
 using OpenXMLTemplates.Utils;
 
-namespace OpenXMLTempaltesTest.CustomPartAdditionTest
+namespace OpenXMLTemplatesTest.CustomPartAdditionTest
 {
     public class CustomPartAdditionTests
     {
@@ -20,8 +20,6 @@ namespace OpenXMLTempaltesTest.CustomPartAdditionTest
 
             Assert.IsNotNull(doc.GetCustomXmlPart("XmlCustomPart"));
             doc.AssertValid();
-
-            doc.Close();
         }
 
         [Test]
@@ -41,8 +39,6 @@ namespace OpenXMLTempaltesTest.CustomPartAdditionTest
             Assert.DoesNotThrow(() => doc.GetCustomXmlParts().Single(e => e.GetNamespace() == "XmlCustomPart"));
 
             doc.AssertValid();
-
-            doc.Close();
         }
 
         private WordprocessingDocument GetDoc()

--- a/OpenXMLTemplatesTest/EngineTest/EngineTest.cs
+++ b/OpenXMLTemplatesTest/EngineTest/EngineTest.cs
@@ -7,7 +7,7 @@ using OpenXMLTemplates.Documents;
 using OpenXMLTemplates.Engine;
 using OpenXMLTemplates.Variables;
 
-namespace OpenXMLTempaltesTest.EngineTest
+namespace OpenXMLTemplatesTest.EngineTest
 {
     public class EngineTest
     {
@@ -57,7 +57,6 @@ namespace OpenXMLTempaltesTest.EngineTest
 
 
             doc.WordprocessingDocument.AssertValid();
-            doc.Close();
         }
         
         [Test]

--- a/OpenXMLTemplatesTest/OpenXMLTemplatesTest.csproj
+++ b/OpenXMLTemplatesTest/OpenXMLTemplatesTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <RootNamespace>OpenXMLTempaltesTest</RootNamespace>
+        <RootNamespace>OpenXMLTemplatesTest</RootNamespace>
         <TargetFramework>net6.0</TargetFramework>
         <FileUpgradeFlags>
         </FileUpgradeFlags>

--- a/OpenXMLTemplatesTest/TestUtils.cs
+++ b/OpenXMLTemplatesTest/TestUtils.cs
@@ -3,7 +3,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using NUnit.Framework;
 
-namespace OpenXMLTempaltesTest
+namespace OpenXMLTemplatesTest
 {
     internal static class TestUtils
     {
@@ -12,7 +12,7 @@ namespace OpenXMLTempaltesTest
         /// </summary>
         internal static string CurrentFolder(this object testObject)
         {
-            var type = testObject.GetType().Namespace?.Replace("OpenXMLTempaltesTest.", "").Replace(".", "/");
+            var type = testObject.GetType().Namespace?.Replace("OpenXMLTemplatesTest.", "").Replace(".", "/");
             return TestContext.CurrentContext.TestDirectory + $"/{type}/";
         }
 

--- a/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
+++ b/OpenXMLTemplatesTest/Variables/VariableSourceTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using OpenXMLTemplates.Variables;
 using OpenXMLTemplates.Variables.Exceptions;
 
-namespace OpenXMLTempaltesTest
+namespace OpenXMLTemplatesTest
 {
     public class DataTests
     {

--- a/OpenXMLTemplatesTest/XMLReplacementTest/XmlReplacementTests.cs
+++ b/OpenXMLTemplatesTest/XMLReplacementTest/XmlReplacementTests.cs
@@ -4,7 +4,7 @@ using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
 using OpenXMLTemplates.Utils;
 
-namespace OpenXMLTempaltesTest.XMLReplacementTest
+namespace OpenXMLTemplatesTest.XMLReplacementTest
 {
     public class XmlReplacementTests
     {
@@ -24,7 +24,6 @@ namespace OpenXMLTempaltesTest.XMLReplacementTest
             doc.AssertValid();
 
 //            doc.SaveAs(TestContext.CurrentContext.TestDirectory + "/XMLReplacementTest/result.docx");
-            doc.Close();
         }
 
         [Test]
@@ -36,8 +35,6 @@ namespace OpenXMLTempaltesTest.XMLReplacementTest
                 XDocument.Load(this.CurrentFolder() + "XMLReplacement.xml");
 
             doc.AddOrReplaceCustomXmlPart(xData);
-
-            doc.Close();
 
 //            Can't be tested directly, because word needs to reevaluate the content controls first         
 //            Assert.AreEqual("NewItem1Value", doc.FindContentControl("item1").GetTextElement().Text);


### PR DESCRIPTION
- Updated `DocumentFormat.OpenXml` to the latest version `3.2.0`.
- Updated `Newtonsoft.Json` to the latest version `13.0.3`.
- Fixed a typo in the word "Template".
- Removed the `Close` method since the object is automatically closed at the end of the `using` block.

fix for #54 